### PR TITLE
Add a binary for visualisation with `vsvg-viewer`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+*.svg

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Cargo.lock
 *.pdb
 
 *.svg
+/venv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ pyo3 = "0.19.0"
 
 # TODO: split the bin into its own crate so we don't pull those deps inti the maturin target
 # TODO: set to 0.4.0 when released
+clap = { version = "4.4.16", features = ["derive"] }
 vsvg = { git = "https://github.com/abey79/vsvg", rev = "86ac544d0c049b3018d6f0a56611965886f0d461" }
 vsvg-viewer = { git = "https://github.com/abey79/vsvg", rev = "86ac544d0c049b3018d6f0a56611965886f0d461" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "beamtable"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = "0.19.0"
+
+# TODO: split the bin into its own crate so we don't pull those deps inti the maturin target
+vsvg = "0.3.0"
+vsvg-viewer = "0.3.0"
+
+# TODO: getting this right is annoying, vsvg should reexport it instead: https://github.com/abey79/vsvg/issues/110
+kurbo = "0.10.4" # let vsvg choose version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ crate-type = ["cdylib", "rlib"]
 pyo3 = "0.19.0"
 
 # TODO: split the bin into its own crate so we don't pull those deps inti the maturin target
-vsvg = "0.3.0"
-vsvg-viewer = "0.3.0"
-
-# TODO: getting this right is annoying, vsvg should reexport it instead: https://github.com/abey79/vsvg/issues/110
-kurbo = "0.10.4" # let vsvg choose version
+# TODO: set to 0.4.0 when released
+vsvg = { git = "https://github.com/abey79/vsvg", rev = "86ac544d0c049b3018d6f0a56611965886f0d461" }
+vsvg-viewer = { git = "https://github.com/abey79/vsvg", rev = "86ac544d0c049b3018d6f0a56611965886f0d461" }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -12,6 +12,12 @@ impl Point {
     }
 }
 
+impl From<(f64, f64)> for Point {
+    fn from(value: (f64, f64)) -> Self {
+        Point::new(value.0, value.1)
+    }
+}
+
 impl Eq for Point {}
 
 impl PartialEq<Self> for Point {
@@ -41,7 +47,6 @@ impl Ord for Point {
         return Ordering::Equal;
     }
 }
-
 
 #[derive(Debug, Clone)]
 pub struct Line {
@@ -80,7 +85,9 @@ impl Line {
         let c = &line.p0;
         let d = &line.p1;
         let denom: f64 = (d.y - c.y) * (b.x - a.x) - (d.x - c.x) * (b.y - a.y);
-        if denom.abs() < 1e-12 { return None; }
+        if denom.abs() < 1e-12 {
+            return None;
+        }
         let t1: f64 = ((d.x - c.x) * (a.y - c.y) - (d.y - c.y) * (a.x - c.x)) / denom;
         let t2: f64 = ((b.x - a.x) * (a.y - c.y) - (b.y - a.y) * (a.x - c.x)) / denom;
         if 0.0 <= t1 && t1 <= 1.0 && 0.0 <= t2 && t2 <= 1.0 {
@@ -107,8 +114,9 @@ impl Line {
     }
 
     pub fn point(&self, t: f64) -> Point {
-        Point::new(t * (self.p1.x - self.p0.x) + self.p0.x, t * (self.p1.y - self.p0.y) + self.p0.y)
+        Point::new(
+            t * (self.p1.x - self.p0.x) + self.p0.x,
+            t * (self.p1.y - self.p0.y) + self.p0.y,
+        )
     }
 }
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
-mod geometry;
 mod events;
-mod scanbeam;
+pub mod geometry;
+pub mod scanbeam;
 mod table;
 
-use pyo3::prelude::*;
 use crate::scanbeam::ScanBeam;
+use pyo3::prelude::*;
 
 ///
 #[pyfunction]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use beamtable::geometry::Line;
 use beamtable::scanbeam::ScanBeam;
-use vsvg::{DocumentTrait, LayerTrait, PathTrait};
+use vsvg::{DocumentTrait, Draw, LayerTrait, PathTrait};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // load a SVG if provided
@@ -51,19 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let layer = doc.get_mut(1);
     for event in beam_table.events {
-        // TODO: this is annoying to do, `Layer` should implement `Draw` https://github.com/abey79/vsvg/issues/109
-        let path = vsvg::Path::from_metadata(
-            kurbo::Circle::new(
-                kurbo::Point {
-                    x: event.x,
-                    y: event.y,
-                },
-                0.5,
-            ),
-            vsvg::PathMetadata::default(),
-        );
-
-        layer.push_path(path);
+        layer.circle(event.x, event.y, 0.5);
     }
 
     vsvg_viewer::show(doc.into())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,72 @@
+use beamtable::geometry::Line;
+use beamtable::scanbeam::ScanBeam;
+use vsvg::{DocumentTrait, LayerTrait, PathTrait};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // load a SVG if provided
+    let path = std::env::args().nth(1).map(std::path::PathBuf::from);
+    let doc = if let Some(path) = path {
+        vsvg::Document::from_svg(&path, true)?
+    } else {
+        vsvg::Document::default()
+    };
+
+    // flatten the document as we only support polyline
+    let doc = doc.flatten(vsvg::DEFAULT_TOLERANCE);
+
+    // convert everything to lines
+    let lines: Vec<_> = doc
+        .layers
+        .values()
+        .flat_map(|layer| {
+            layer.paths.iter().flat_map(|path| {
+                path.data
+                    .points()
+                    .windows(2)
+                    .map(|p| ((p[0].x(), p[0].y()), (p[1].x(), p[1].y())))
+            })
+        })
+        .enumerate()
+        .map(|(i, (p0, p1))| Line::new(p0, p1, i))
+        .collect();
+
+    // run scan beam algorithm
+    let mut scanbeam = ScanBeam::new(lines);
+    let beam_table = scanbeam.build();
+
+    //
+    // visualize the result
+    //
+
+    // convert back to regular (not flattened) document, merge everything to layer 0 and normalize
+    // line width and color
+    let mut doc = vsvg::Document::from(doc);
+    doc.merge_layers();
+    doc.for_each(|layer| {
+        layer.for_each(|path| {
+            path.metadata_mut().stroke_width = 0.5;
+            path.metadata_mut().color = vsvg::Color::LIGHT_RED;
+        });
+    });
+
+    let layer = doc.get_mut(1);
+    for event in beam_table.events {
+        // TODO: this is annoying to do, `Layer` should implement `Draw` https://github.com/abey79/vsvg/issues/109
+        let path = vsvg::Path::from_metadata(
+            kurbo::Circle::new(
+                kurbo::Point {
+                    x: event.x,
+                    y: event.y,
+                },
+                0.5,
+            ),
+            vsvg::PathMetadata::default(),
+        );
+
+        layer.push_path(path);
+    }
+
+    vsvg_viewer::show(doc.into())?;
+
+    Ok(())
+}

--- a/src/scanbeam.rs
+++ b/src/scanbeam.rs
@@ -1,7 +1,7 @@
-use std::cmp::Ordering;
 use crate::events::Event;
 use crate::geometry::{Line, Point};
 use crate::table::BeamTable;
+use std::cmp::Ordering;
 
 pub struct ScanBeam {
     pub segments: Vec<Line>,
@@ -12,7 +12,7 @@ pub struct ScanBeam {
 }
 
 impl ScanBeam {
-    pub(crate) fn new(segments: Vec<Line>) -> ScanBeam {
+    pub fn new(segments: Vec<Line>) -> ScanBeam {
         ScanBeam {
             segments,
             events: Vec::new(),
@@ -89,14 +89,18 @@ impl ScanBeam {
                 let t1 = t.0;
                 let t2 = t.1;
                 // println!("{t1}, {t2}");
-                if ((t1 == 0.0 || t1 == 1.0)) && ((t2 == 0.0) || (t2 == 1.0)) {
+                if (t1 == 0.0 || t1 == 1.0) && ((t2 == 0.0) || (t2 == 1.0)) {
                     return;
                 }
                 let pt_intersect = line1.point(t1);
                 self.intersections.push(pt_intersect.clone());
                 match Point::cmp(&sl, &pt_intersect) {
-                    Ordering::Greater => { return; }
-                    Ordering::Equal => { return; }
+                    Ordering::Greater => {
+                        return;
+                    }
+                    Ordering::Equal => {
+                        return;
+                    }
                     Ordering::Less => {}
                 }
                 checked_swaps.push((q, r));
@@ -106,14 +110,18 @@ impl ScanBeam {
                     swap: Some((q, r)),
                 };
                 match self.events.binary_search(&event) {
-                    Ok(insert) => { self.events.insert(insert, event); }
-                    Err(insert) => { self.events.insert(insert, event); }
+                    Ok(insert) => {
+                        self.events.insert(insert, event);
+                    }
+                    Err(insert) => {
+                        self.events.insert(insert, event);
+                    }
                 }
             }
         }
     }
 
-    pub(crate) fn build(&mut self) -> BeamTable {
+    pub fn build(&mut self) -> BeamTable {
         let events = &mut self.events;
         let segments = &self.segments;
         for (i, segment) in segments.iter().enumerate() {
@@ -170,7 +178,11 @@ impl ScanBeam {
                         }
                     } else {
                         //Remove.
-                        let rp = self.actives.iter().position(|&e| e == !index).expect("Was added should remove.");
+                        let rp = self
+                            .actives
+                            .iter()
+                            .position(|&e| e == !index)
+                            .expect("Was added should remove.");
                         self.actives.remove(rp);
                         if 0 < rp && rp < self.actives.len() {
                             self.check_intersections(rp - 1, rp, pt)
@@ -178,7 +190,11 @@ impl ScanBeam {
                     }
                 }
                 Some((s1, _)) => {
-                    let s1 = self.actives.iter().position(|&e| e == s1).expect("Swap pos should exist.");
+                    let s1 = self
+                        .actives
+                        .iter()
+                        .position(|&e| e == s1)
+                        .expect("Swap pos should exist.");
                     let s2 = s1 + 1;
                     self.actives.swap(s1, s2);
                     if s1 > 0 {


### PR DESCRIPTION
This PR adds a CLI binary to load a SVG and visualise the events. The SVG is loaded into a single layer and flattened before processing by `beamtable`. Then the resulting events are displayed on top of the original lines.

This PR also has a few formatting changes that are a byproduct of my IDE running `rustfmt` on everything.

#### Usage

```
cargo run -- --show my_file.svg
cargo run -- --save output my_file.svg
```

<img width="912" alt="image" src="https://github.com/tatarize/beamtable/assets/49431240/889cb4e6-0f0f-4b18-b708-381e64b5892c">


#### Limitations

- This PR pulls the `vsvg` dependency into the `beamtable` crate. Although this should have no consequence, it would be cleaner to split the binary into its own crate.
- Currently, only events are displayed. 
- When vsvg has support for text (WIP), it will be easy to annotate events.